### PR TITLE
Add support for shell compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ cmake-build-*/
 modules.xml
 .idea/misc.xml
 *.ipr
+
+# Ignore by-products of compilation
+lib/
+obj/
+

--- a/cpp/graphviewer.cpp
+++ b/cpp/graphviewer.cpp
@@ -20,7 +20,11 @@ void GraphViewer::initialize(int width, int height, bool dynamic, int port_n) {
 	this->width = width;
 	this->height = height;
 	this->isDynamic = dynamic;
-	string command = "java -jar GraphViewerController.jar";
+	string command = "java -jar ";
+	#ifdef PWD
+		command += string(PWD) + "/";
+	#endif
+	command += "GraphViewerController.jar";	
 	std::stringstream ss;
 	ss << port_n;
 	string port_string = ss.str();

--- a/makefile
+++ b/makefile
@@ -25,5 +25,5 @@ $(ODIR):
 $(LDIR):
 	mkdir -p $(LDIR)
 
-$(ODIR)/%.o: $(ODIR) $(SDIR)/%.cpp
-	$(CC) $(CFLAGS) -c $^ -o $@ -DPWD='"$(shell pwd)"'
+$(ODIR)/%.o: $(SDIR)/%.cpp $(ODIR)
+	$(CC) $(CFLAGS) -c $< -o $@ -DPWD='"$(shell pwd)"'

--- a/makefile
+++ b/makefile
@@ -1,0 +1,29 @@
+SDIR=./cpp
+ODIR=./obj
+LDIR=./lib
+LIB=$(LDIR)/libgraphviewer.a
+
+CC     =g++
+
+CFLAGS =$(IFLAGS) -Dlinux
+
+O_FILES=$(ODIR)/graphviewer.o $(ODIR)/connection.o
+
+all: $(LIB)
+
+clean:
+	rm -rf $(ODIR)
+	rm -rf $(LDIR)
+
+$(LIB): $(LDIR) $(O_FILES)
+	rm -f $(LIB)
+	ar rvs $(LIB) $(O_FILES)
+
+$(ODIR):
+	mkdir -p $(ODIR)
+
+$(LDIR):
+	mkdir -p $(LDIR)
+
+$(ODIR)/%.o: $(ODIR) $(SDIR)/%.cpp
+	$(CC) $(CFLAGS) -c $^ -o $@ -DPWD='"$(shell pwd)"'


### PR DESCRIPTION
1. Created makefile allowing to compile source code files into a static library in `lib/libgraphviewer.a` using `g++`. This allows one to easily use it, as it is a mere static library: when compiling with `g++`, use the option `-L/path/to/graphview/lib` to tell the linker where to look for libraries, and `-lgraphviewer` to link to `lib/libgraphviewer.a`.

2. Also *corrected* bug where the GraphViewer source code could not find `GraphViewerController.jar` if the executable was in a different folder than `GraphViewerController.jar`. Corrected by defining macro PWD GraphViewer compilation, containing the path to the base folder of the repo. This macro is then used while compilating to reference `GraphViewerController.jar` with an absolute path. This means the executable can now be moved wherever you want and still work, as long as `GraphViewerController.jar` does not change path.

One can still use the *uncorrected* version of 2. by simply not defining macro PWD in the makefile.

